### PR TITLE
Add wiki page on repro steps.

### DIFF
--- a/Jenkins-Build-Triggers.md
+++ b/Jenkins-Build-Triggers.md
@@ -1,0 +1,168 @@
+You can trigger individual Jenkins builds on a PR by writing a comment with the following pattern:
+
+```
+@dotnet-bot test [build-name] please
+```
+
+Where `[build-name]` is the name of the check as it appears at the bottom of a PR.
+The specific comments needed to trigger the builds are listed below.
+
+# Default Jenkins Builds
+
+This is the set of builds that should be triggered by default on a pull request. (Linux builds will
+only be triggered for branches that support Linux builds.)
+
+To re-run the full set of builds:
+
+```
+@dotnet-bot test this please
+```
+
+To re-run individual builds:
+
+```
+@dotnet-bot test Copyright Check please
+@dotnet-bot test EOL Check please
+
+@dotnet-bot test Windows x64_debug please
+@dotnet-bot test Windows x64_release please
+@dotnet-bot test Windows x64_test please
+@dotnet-bot test Windows x86_debug please
+@dotnet-bot test Windows x86_release please
+@dotnet-bot test Windows x86_test please
+@dotnet-bot test Windows arm_debug please
+@dotnet-bot test Windows arm_release please
+@dotnet-bot test Windows arm_test please
+
+@dotnet-bot test Ubuntu ubuntu_linux_debug please
+@dotnet-bot test Ubuntu ubuntu_linux_debug_static please
+@dotnet-bot test Ubuntu ubuntu_linux_release please
+@dotnet-bot test Ubuntu ubuntu_linux_release_static please
+@dotnet-bot test Ubuntu ubuntu_linux_test please
+@dotnet-bot test Ubuntu ubuntu_linux_test_static please
+```
+
+# Daily Builds
+
+The following are commands which can be used to run daily build configurations on a PR,
+which can be useful for validating fixes.
+
+## Builds with Slow Tests
+
+Run the full set:
+
+```
+@dotnet-bot test slow tests please
+```
+
+Run individual builds:
+
+```
+@dotnet-bot test Windows daily_slow_x64_debug please
+@dotnet-bot test Windows daily_slow_x64_release please
+@dotnet-bot test Windows daily_slow_x64_test please
+@dotnet-bot test Windows daily_slow_x86_debug please
+@dotnet-bot test Windows daily_slow_x86_release please
+@dotnet-bot test Windows daily_slow_x86_test please
+@dotnet-bot test Windows daily_slow_arm_debug please
+@dotnet-bot test Windows daily_slow_arm_release please
+@dotnet-bot test Windows daily_slow_arm_test please
+```
+
+## Linux Builds
+
+Run the full set:
+
+```
+@dotnet-bot test linux tests please
+```
+
+Run individual builds:
+
+```
+@dotnet-bot test Ubuntu daily_ubuntu_linux_debug please
+@dotnet-bot test Ubuntu daily_ubuntu_linux_debug_static please
+@dotnet-bot test Ubuntu daily_ubuntu_linux_release please
+@dotnet-bot test Ubuntu daily_ubuntu_linux_release_static please
+@dotnet-bot test Ubuntu daily_ubuntu_linux_test please
+@dotnet-bot test Ubuntu daily_ubuntu_linux_test_static please
+```
+
+## DisableJIT Builds
+
+Run the full set (use either one of the following):
+
+```
+@dotnet-bot test nojit tests please
+@dotnet-bot test disablejit tests please
+```
+
+Run individual builds:
+
+```
+@dotnet-bot test Windows daily_disablejit_x64_debug please
+@dotnet-bot test Windows daily_disablejit_x64_release please
+@dotnet-bot test Windows daily_disablejit_x64_test please
+@dotnet-bot test Windows daily_disablejit_x86_debug please
+@dotnet-bot test Windows daily_disablejit_x86_release please
+@dotnet-bot test Windows daily_disablejit_x86_test please
+@dotnet-bot test Windows daily_disablejit_arm_debug please
+@dotnet-bot test Windows daily_disablejit_arm_release please
+@dotnet-bot test Windows daily_disablejit_arm_test please
+```
+
+## Legacy Builds
+
+Run the full set (use either one of the following):
+
+```
+@dotnet-bot test dev12 tests please
+@dotnet-bot test legacy tests please
+```
+
+Run individual builds:
+
+```
+@dotnet-bot test Windows 7 daily_dev12_x64_debug please
+@dotnet-bot test Windows 7 daily_dev12_x64_release please
+@dotnet-bot test Windows 7 daily_dev12_x64_test please
+@dotnet-bot test Windows 7 daily_dev12_x86_debug please
+@dotnet-bot test Windows 7 daily_dev12_x86_release please
+@dotnet-bot test Windows 7 daily_dev12_x86_test please
+```
+
+# Test Jenkins CI Script Changes
+
+## Locally
+
+It is also a good idea to validate the changes locally.
+
+You can run the following script to generate XML files to validate changes:
+[Local-Job-Gen.ps1](https://github.com/dotnet/dotnet-ci/blob/master/tools/Local-Job-Gen.ps1) 
+
+* Download https://github.com/dotnet/dotnet-ci/blob/master/tools/Local-Job-Gen.ps1
+* Run `Local-Job-Gen.ps1` with the old version of the `.groovy` script to create a baseline:
+
+`powershell .\Local-Job-Gen.ps1 -CIFile "C:\dev\ChakraCore\netci.groovy" -CIOutputDir "C:\debugging\netci\master-baseline" -Branch master`
+
+* Run `Local-Job-Gen.ps1` with the changes to the `.groovy` script and output to a different folder:
+
+`powershell .\Local-Job-Gen.ps1 -CIFile "C:\dev\ChakraCore\netci.groovy" -CIOutputDir "C:\debugging\netci\master" -Branch master`
+
+* Do a directory diff to make sure the changes to the XML files are what you expected.
+
+Note: one XML file is created per job generated.
+
+## With Jenkins (on PRs)
+
+When making changes to `*.groovy` scripts related to the Jenkins CI checks, you can request the following
+to validate the changes.
+
+```
+@dotnet-bot test ci please
+```
+
+This will tell you whether the Groovy script compiles.
+You will also be able to examine the generated jobs to make sure the changes are what you expected.
+
+It is easier to validate changes locally so that's usually the best place to start.

--- a/Jenkins-CI-Checks.md
+++ b/Jenkins-CI-Checks.md
@@ -31,6 +31,11 @@ If you would like to re-run all of the Jenkins tests:
 @dotnet-bot test this please
 ```
 
+For more specifics on when and how to trigger specific builds, please see:
+
+* [[Jenkins Build Triggers]]
+* [[Jenkins Repro Steps]]
+
 # Making changes to the Jenkins CI configuration.
 
 If you want to change or add build configurations into Jenkins CI, you will need to update the [netci.groovy](https://github.com/Microsoft/ChakraCore/blob/master/netci.groovy) file, and create a Pull Request. To verify the configuration change did what you expected, you should ask __@dotnet-bot__ to test the change to the CI, like so:

--- a/Jenkins-Repro-Steps.md
+++ b/Jenkins-Repro-Steps.md
@@ -1,0 +1,168 @@
+When Jenkins builds or tests fail it is helpful to be able to reproduce the errors locally.
+
+It is possible to run builds and tests locally using the same scripts that the Jenkins checks use.
+To run these commands, please follow the instructions below.
+
+Keep in mind that certain builds will have system requirements that make it impossible
+to run the builds directly on your system configurations
+(e.g. Legacy Windows builds which require Windows 7 and/or VS 2013;
+and Linux builds which require a Linux system or VM).
+Requirements are detailed below.
+
+The following Jenkins commands are directed at re-running entire sets of Jenkins checks.
+If you wish to re-run a *particular* check, see [[Jenkins Build Triggers]].
+
+# Rolling Builds
+
+## Windows
+
+Repro with these commands:
+
+```
+jenkins\buildone.cmd x64 debug
+jenkins\testone.cmd x64 debug
+```
+
+When testing a fix to these builds with Jenkins **you do NOT need to request any additional tests**
+because this set of tests is automatic.
+If you wish to **RE-RUN tests** due to, e.g., intermittent failures, you can request:
+
+```
+@dotnet-bot test this please
+```
+
+## Linux
+
+Repro with these commands:
+
+```
+./build.sh --debug
+./test/runtests.sh -d
+```
+
+When testing a fix to these builds with Jenkins **you do NOT need to request any additional tests**
+because this set of tests is automatic.
+If you wish to **RE-RUN tests** due to, e.g., intermittent failures, you can request:
+
+```
+@dotnet-bot test this please
+```
+
+# Daily Builds
+
+## Builds with Slow Tests
+
+Builds with Slow Tests are used for daily builds, but are *mostly* the same as the rolling builds above.
+**Only trigger these builds if there is an issue revealed in the dailies that does not repro in the
+rolling builds (to save build machine resources).**
+
+### Windows (Daily)
+
+Repro with these commands:
+
+```
+jenkins\buildone.cmd x64 debug
+jenkins\testone.cmd x64 debug -includeSlow
+```
+
+When testing a fix please request:
+
+```
+@dotnet-bot test slow tests please
+```
+
+### Linux (Daily)
+
+Repro with these commands:
+
+```
+./build.sh --debug
+./test/runtests.sh -d
+```
+
+When testing a fix please request:
+
+```
+@dotnet-bot test linux tests please
+```
+
+## DisableJIT Builds (Windows-only)
+
+Repro with these commands:
+
+```
+jenkins\buildone.cmd x64 debug "/p:BuildJIT=false"
+jenkins\testone.cmd x64 debug -disablejit
+```
+
+When testing a fix please request:
+
+```
+@dotnet-bot test nojit tests please
+```
+
+(You can also replace `test nojit tests` with `test disablejit tests` if you prefer -- they are equivalent.)
+
+## Legacy Builds (Windows-only)
+
+_Note: **These tests are designed to run under VS 2013 + Windows 7.**
+In most cases, failures are related to running under msbuild 12.0 so you can most likely
+reproduce failures using msbuild 12.0 without needing to run on Windows 7. If you still cannot repro,
+you might consider setting up a Windows 7 VM to repro._
+
+Repro with these commands:
+
+```
+jenkins\buildone.cmd x64 debug msbuild12
+jenkins\testone.cmd x64 debug -win7 -includeSlow
+```
+
+When testing a fix please request the following:
+
+```
+@dotnet-bot test dev12 tests please
+```
+
+(You can also replace `test dev12 tests` with `test legacy tests` if you prefer -- they are equivalent.)
+
+# Footnotes
+
+## Windows Alternate Flags
+
+You can replace `x64` with `x86` or `arm`. (Running tests on `arm` builds is not supported).
+
+You can replace `debug` with `test` or `release`. (Running tests on `release` builds is not supported).
+
+## Linux Alternate Flags
+
+See [Building ChakraCore](https://github.com/Microsoft/ChakraCore/wiki/Building-ChakraCore#linux)
+
+You can replace `--debug` with `--test-build` or omit this flag for a release build.
+
+You can replace `-d` (corresponding with `--debug` in `build.sh`)
+with `-t` (corresponding with `--test-build` in `build.sh`).
+
+(Running tests on release builds is not supported.)
+
+## Systems
+
+See [Building ChakraCore](https://github.com/Microsoft/ChakraCore/wiki/Building-ChakraCore)
+for specific details on the platforms and build configurations we support and requirements to build them.
+
+* **Windows:** We will primarily support Windows 8.1+ with VS 2015.
+We currently support systems with Windows 7 or VS 2013 as Legacy configurations.
+* **Linux:** We will support Ubuntu 16.04 LTS with Clang 3.8+.
+* **OS X:** We will support OS X with Clang 3.8+.
+
+## Shorthand and System Compatibility Notes
+
+For purposes of shorthand the following terms are considered more or less equivalent here:
+
+* VS 2015 = Visual Studio 2015 = Dev14 = msbuild 14.0
+* VS 2013 = Visual Studio 2013 = Dev12 = msbuild 12.0
+
+Compatibility testing notes:
+
+* All of our compatibility is either targeted at Windows 7 SP1 or Windows 8.1+ (which includes Windows 10).
+* Windows 7 SP1 is actually tested on Windows Server 2008 R2 (for our purposes, an equivalent Server OS).
+* Windows 8.1+ is actually tested on Windows Server 2012 R2 (for our purposes, an equivalent Server OS).

--- a/_Sidebar.md
+++ b/_Sidebar.md
@@ -10,6 +10,8 @@
 * [Contributor Guidance](https://github.com/Microsoft/ChakraCore/blob/master/CONTRIBUTING.md)
   * [[Coding Convention]]
   * [[Jenkins CI Checks]]
+  * [[Jenkins Build Triggers]]
+  * [[Jenkins Repro Steps]]
 * [[Embedding ChakraCore]]
   * [[JavaScript Runtime (JSRT) Overview]]
   * [[JavaScript Runtime (JSRT) Reference]]


### PR DESCRIPTION
It is helpful to be able to instruct people on how to reproduce Jenkins issues locally. Unfortunately it is not as simple as I'd to reconstruct the necessary commands from the `netci.groovy` file. Having this reference should help reduce time and errors in instructing people on how to repro Jenkins issues. The commands have not changed in a long time so I think it is reasonably stable and ready for entry in the Wiki.
