### PR TITLE
Rename LICENSE{.md -> .txt} and clarify language to ensure it is understood that this license applies only to the Wiki.

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (C) Microsoft Corporation. All rights reserved. Distributed under the following terms:
+Copyright (C) Microsoft Corporation. All rights reserved. The ChakraCore Wiki is distributed under the following terms:
 
 1.	Documentation is licensed under the [Creative Commons Attribution 3.0 United States License](http://creativecommons.org/licenses/by/3.0/us/legalcode). Code is licensed under the [MIT License](http://opensource.org/licenses/MIT).
 


### PR DESCRIPTION
Renaming the LICENSE.md to LICENSE.txt ensures that it does not show up in the Wiki (.md files show up but .txt files like README.txt do not) as [LICENSE](https://github.com/Microsoft/ChakraCore/wiki/LICENSE) as it does now. Not exposing this LICENSE file through the Wiki view reduces the likelihood that people could mistake this LICENSE file as the LICENSE of ChakraCore's source code (that license is found in [ChakraCore's LICENSE.txt file](https://github.com/Microsoft/ChakraCore/blob/master/LICENSE.txt).

This change also clarifies the language of the LICENSE.txt file to indicate that it applies to the ChakraCore wiki (and not the ChakraCore source code).