### PR TITLE
Update Jenkins links to https://ci.dot.net because http://dotnet-ci.cloudapp.net is deprecated.

### DIFF
--- a/Build-Status-(release-1.2).md
+++ b/Build-Status-(release-1.2).md
@@ -12,26 +12,26 @@ For every commit we build and test of all of our build configurations on Windows
 
 *If you see badges reading "Build: Unknown" it is likely because a build was skipped due to changes being only in files known not to affect the health of the build.*
 
-[x64dbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/x64_debug/badge/icon
-[x64dbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/x64_debug/
-[x64testicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/x64_test/badge/icon
-[x64testlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/x64_test/
-[x64relicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/x64_release/badge/icon
-[x64rellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/x64_release/
+[x64dbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/x64_debug/badge/icon
+[x64dbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/x64_debug/
+[x64testicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/x64_test/badge/icon
+[x64testlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/x64_test/
+[x64relicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/x64_release/badge/icon
+[x64rellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/x64_release/
 
-[x86dbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/x86_debug/badge/icon
-[x86dbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/x86_debug/
-[x86testicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/x86_test/badge/icon
-[x86testlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/x86_test/
-[x86relicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/x86_release/badge/icon
-[x86rellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/x86_release/
+[x86dbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/x86_debug/badge/icon
+[x86dbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/x86_debug/
+[x86testicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/x86_test/badge/icon
+[x86testlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/x86_test/
+[x86relicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/x86_release/badge/icon
+[x86rellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/x86_release/
 
-[armdbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/arm_debug/badge/icon
-[armdbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/arm_debug/
-[armtesticon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/arm_test/badge/icon
-[armtestlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/arm_test/
-[armrelicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/arm_release/badge/icon
-[armrellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/arm_release/
+[armdbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/arm_debug/badge/icon
+[armdbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/arm_debug/
+[armtesticon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/arm_test/badge/icon
+[armtestlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/arm_test/
+[armrelicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/arm_release/badge/icon
+[armrellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/arm_release/
 
 # Daily Builds
 
@@ -45,26 +45,26 @@ Once a day, we run all the same builds as the Rolling Builds above, but we run a
 | __Windows (x86)__ | [![dslowx86debug][dslowx86dbgicon]][dslowx86dbglink] | [![dslowx86test][dslowx86testicon]][dslowx86testlink] | [![dslowx86release][dslowx86relicon]][dslowx86rellink] |
 | __Windows (ARM)__ | [![dslowarmdebug][dslowarmdbgicon]][dslowarmdbglink] | [![dslowarmtest][dslowarmtesticon]][dslowarmtestlink] | [![dslowarmrelease][dslowarmrelicon]][dslowarmrellink] |
 
-[dslowx64dbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_x64_debug/badge/icon
-[dslowx64dbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_x64_debug/
-[dslowx64testicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_x64_test/badge/icon
-[dslowx64testlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_x64_test/
-[dslowx64relicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_x64_release/badge/icon
-[dslowx64rellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_x64_release/
+[dslowx64dbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_x64_debug/badge/icon
+[dslowx64dbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_x64_debug/
+[dslowx64testicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_x64_test/badge/icon
+[dslowx64testlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_x64_test/
+[dslowx64relicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_x64_release/badge/icon
+[dslowx64rellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_x64_release/
 
-[dslowx86dbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_x86_debug/badge/icon
-[dslowx86dbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_x86_debug/
-[dslowx86testicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_x86_test/badge/icon
-[dslowx86testlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_x86_test/
-[dslowx86relicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_x86_release/badge/icon
-[dslowx86rellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_x86_release/
+[dslowx86dbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_x86_debug/badge/icon
+[dslowx86dbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_x86_debug/
+[dslowx86testicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_x86_test/badge/icon
+[dslowx86testlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_x86_test/
+[dslowx86relicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_x86_release/badge/icon
+[dslowx86rellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_x86_release/
 
-[dslowarmdbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_arm_debug/badge/icon
-[dslowarmdbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_arm_debug/
-[dslowarmtesticon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_arm_test/badge/icon
-[dslowarmtestlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_arm_test/
-[dslowarmrelicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_arm_release/badge/icon
-[dslowarmrellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_arm_release/
+[dslowarmdbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_arm_debug/badge/icon
+[dslowarmdbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_arm_debug/
+[dslowarmtesticon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_arm_test/badge/icon
+[dslowarmtestlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_arm_test/
+[dslowarmrelicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_arm_release/badge/icon
+[dslowarmrellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_slow_arm_release/
 
 ## DisableJIT Builds
 
@@ -76,26 +76,26 @@ Once a day, we run all of our usual build configurations with JIT excluded from 
 | __Windows (x86)__ | [![ddjx86debug][ddjx86dbgicon]][ddjx86dbglink] | [![ddjx86test][ddjx86testicon]][ddjx86testlink] | [![ddjx86release][ddjx86relicon]][ddjx86rellink] |
 | __Windows (ARM)__ | [![ddjarmdebug][ddjarmdbgicon]][ddjarmdbglink] | [![ddjarmtest][ddjarmtesticon]][ddjarmtestlink] | [![ddjarmrelease][ddjarmrelicon]][ddjarmrellink] |
 
-[ddjx64dbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_x64_debug/badge/icon
-[ddjx64dbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_x64_debug/
-[ddjx64testicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_x64_test/badge/icon
-[ddjx64testlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_x64_test/
-[ddjx64relicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_x64_release/badge/icon
-[ddjx64rellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_x64_release/
+[ddjx64dbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_x64_debug/badge/icon
+[ddjx64dbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_x64_debug/
+[ddjx64testicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_x64_test/badge/icon
+[ddjx64testlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_x64_test/
+[ddjx64relicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_x64_release/badge/icon
+[ddjx64rellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_x64_release/
 
-[ddjx86dbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_x86_debug/badge/icon
-[ddjx86dbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_x86_debug/
-[ddjx86testicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_x86_test/badge/icon
-[ddjx86testlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_x86_test/
-[ddjx86relicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_x86_release/badge/icon
-[ddjx86rellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_x86_release/
+[ddjx86dbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_x86_debug/badge/icon
+[ddjx86dbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_x86_debug/
+[ddjx86testicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_x86_test/badge/icon
+[ddjx86testlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_x86_test/
+[ddjx86relicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_x86_release/badge/icon
+[ddjx86rellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_x86_release/
 
-[ddjarmdbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_arm_debug/badge/icon
-[ddjarmdbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_arm_debug/
-[ddjarmtesticon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_arm_test/badge/icon
-[ddjarmtestlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_arm_test/
-[ddjarmrelicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_arm_release/badge/icon
-[ddjarmrellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_arm_release/
+[ddjarmdbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_arm_debug/badge/icon
+[ddjarmdbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_arm_debug/
+[ddjarmtesticon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_arm_test/badge/icon
+[ddjarmtestlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_arm_test/
+[ddjarmrelicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_arm_release/badge/icon
+[ddjarmrellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_disablejit_arm_release/
 
 ## Legacy Builds
 
@@ -106,16 +106,16 @@ Once a day, we run builds of some configurations using Windows 7 (Windows Server
 | __Windows (x64)__ | [![dd12x64dbg][dd12x64dbgicon]][dd12x64dbglink] | [![dd12x64test][dd12x64testicon]][dd12x64testlink] | [![dd12x64release][dd12x64relicon]][dd12x64rellink] |
 | __Windows (x86)__ | [![dd12x86dbg][dd12x86dbgicon]][dd12x86dbglink] | [![dd12x86test][dd12x86testicon]][dd12x86testlink] | [![dd12x86release][dd12x86relicon]][dd12x86rellink] |
 
-[dd12x64dbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_dev12_x64_debug/badge/icon
-[dd12x64dbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_dev12_x64_debug/
-[dd12x64testicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_dev12_x64_test/badge/icon
-[dd12x64testlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_dev12_x64_test/
-[dd12x64relicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_dev12_x64_release/badge/icon
-[dd12x64rellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_dev12_x64_release/
+[dd12x64dbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_dev12_x64_debug/badge/icon
+[dd12x64dbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_dev12_x64_debug/
+[dd12x64testicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_dev12_x64_test/badge/icon
+[dd12x64testlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_dev12_x64_test/
+[dd12x64relicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_dev12_x64_release/badge/icon
+[dd12x64rellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_dev12_x64_release/
 
-[dd12x86dbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_dev12_x86_debug/badge/icon
-[dd12x86dbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_dev12_x86_debug/
-[dd12x86testicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_dev12_x86_test/badge/icon
-[dd12x86testlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_dev12_x86_test/
-[dd12x86relicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_dev12_x86_release/badge/icon
-[dd12x86rellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_dev12_x86_release/
+[dd12x86dbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_dev12_x86_debug/badge/icon
+[dd12x86dbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_dev12_x86_debug/
+[dd12x86testicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_dev12_x86_test/badge/icon
+[dd12x86testlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_dev12_x86_test/
+[dd12x86relicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_dev12_x86_release/badge/icon
+[dd12x86rellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.2/job/daily_dev12_x86_release/

--- a/Build-Status-(release-1.3).md
+++ b/Build-Status-(release-1.3).md
@@ -15,47 +15,47 @@ For every commit we build and test of all of our build configurations on Windows
 
 *If you see badges reading "Build: Unknown" it is likely because a build was skipped due to changes being only in files known not to affect the health of the build.*
 
-[x64dbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/x64_debug/badge/icon
-[x64dbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/x64_debug/
-[x64testicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/x64_test/badge/icon
-[x64testlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/x64_test/
-[x64relicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/x64_release/badge/icon
-[x64rellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/x64_release/
+[x64dbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/x64_debug/badge/icon
+[x64dbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/x64_debug/
+[x64testicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/x64_test/badge/icon
+[x64testlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/x64_test/
+[x64relicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/x64_release/badge/icon
+[x64rellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/x64_release/
 
-[x86dbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/x86_debug/badge/icon
-[x86dbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/x86_debug/
-[x86testicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/x86_test/badge/icon
-[x86testlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/x86_test/
-[x86relicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/x86_release/badge/icon
-[x86rellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/x86_release/
+[x86dbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/x86_debug/badge/icon
+[x86dbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/x86_debug/
+[x86testicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/x86_test/badge/icon
+[x86testlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/x86_test/
+[x86relicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/x86_release/badge/icon
+[x86rellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/x86_release/
 
-[armdbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/arm_debug/badge/icon
-[armdbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/arm_debug/
-[armtesticon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/arm_test/badge/icon
-[armtestlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/arm_test/
-[armrelicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/arm_release/badge/icon
-[armrellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/arm_release/
+[armdbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/arm_debug/badge/icon
+[armdbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/arm_debug/
+[armtesticon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/arm_test/badge/icon
+[armtestlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/arm_test/
+[armrelicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/arm_release/badge/icon
+[armrellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/arm_release/
 
-[linuxdbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/ubuntu_linux_debug/badge/icon
-[linuxdbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/ubuntu_linux_debug/
-[linuxtesticon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/ubuntu_linux_test/badge/icon
-[linuxtestlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/ubuntu_linux_test/
-[linuxrelicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/ubuntu_linux_release/badge/icon
-[linuxrellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/ubuntu_linux_release/
+[linuxdbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/ubuntu_linux_debug/badge/icon
+[linuxdbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/ubuntu_linux_debug/
+[linuxtesticon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/ubuntu_linux_test/badge/icon
+[linuxtestlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/ubuntu_linux_test/
+[linuxrelicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/ubuntu_linux_release/badge/icon
+[linuxrellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/ubuntu_linux_release/
 
-[linuxsdbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/ubuntu_linux_debug_static/badge/icon
-[linuxsdbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/ubuntu_linux_debug_static/
-[linuxstesticon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/ubuntu_linux_test_static/badge/icon
-[linuxstestlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/ubuntu_linux_test_static/
-[linuxsrelicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/ubuntu_linux_release_static/badge/icon
-[linuxsrellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/ubuntu_linux_release_static/
+[linuxsdbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/ubuntu_linux_debug_static/badge/icon
+[linuxsdbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/ubuntu_linux_debug_static/
+[linuxstesticon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/ubuntu_linux_test_static/badge/icon
+[linuxstestlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/ubuntu_linux_test_static/
+[linuxsrelicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/ubuntu_linux_release_static/badge/icon
+[linuxsrellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/ubuntu_linux_release_static/
 
-[osxsdbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/osx_osx_debug_static/badge/icon
-[osxsdbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/osx_osx_debug_static/
-[osxstesticon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/osx_osx_test_static/badge/icon
-[osxstestlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/osx_osx_test_static/
-[osxsrelicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/osx_osx_release_static/badge/icon
-[osxsrellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/osx_osx_release_static/
+[osxsdbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/osx_osx_debug_static/badge/icon
+[osxsdbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/osx_osx_debug_static/
+[osxstesticon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/osx_osx_test_static/badge/icon
+[osxstestlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/osx_osx_test_static/
+[osxsrelicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/osx_osx_release_static/badge/icon
+[osxsrellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/osx_osx_release_static/
 
 # Daily Builds
 
@@ -72,47 +72,47 @@ Once a day, we run all the same builds as the Rolling Builds above, but we run a
 | __Ubuntu 16.04 (x64 static)__ | [![dslowlinuxsdebug][dslowlinuxsdbgicon]][dslowlinuxsdbglink] | [![dslowlinuxstest][dslowlinuxstesticon]][dslowlinuxstestlink] | [![dslowlinuxsrelease][dslowlinuxsrelicon]][dslowlinuxsrellink] |
 | __OS X 10.9 (x64 static)__    | [![dslowosxsdebug][dslowosxsdbgicon]][dslowosxsdbglink] | [![dslowosxstest][dslowosxstesticon]][dslowosxstestlink] | [![dslowosxsrelease][dslowosxsrelicon]][dslowosxsrellink] |
 
-[dslowx64dbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_x64_debug/badge/icon
-[dslowx64dbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_x64_debug/
-[dslowx64testicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_x64_test/badge/icon
-[dslowx64testlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_x64_test/
-[dslowx64relicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_x64_release/badge/icon
-[dslowx64rellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_x64_release/
+[dslowx64dbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_x64_debug/badge/icon
+[dslowx64dbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_x64_debug/
+[dslowx64testicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_x64_test/badge/icon
+[dslowx64testlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_x64_test/
+[dslowx64relicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_x64_release/badge/icon
+[dslowx64rellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_x64_release/
 
-[dslowx86dbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_x86_debug/badge/icon
-[dslowx86dbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_x86_debug/
-[dslowx86testicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_x86_test/badge/icon
-[dslowx86testlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_x86_test/
-[dslowx86relicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_x86_release/badge/icon
-[dslowx86rellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_x86_release/
+[dslowx86dbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_x86_debug/badge/icon
+[dslowx86dbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_x86_debug/
+[dslowx86testicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_x86_test/badge/icon
+[dslowx86testlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_x86_test/
+[dslowx86relicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_x86_release/badge/icon
+[dslowx86rellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_x86_release/
 
-[dslowarmdbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_arm_debug/badge/icon
-[dslowarmdbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_arm_debug/
-[dslowarmtesticon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_arm_test/badge/icon
-[dslowarmtestlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_arm_test/
-[dslowarmrelicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_arm_release/badge/icon
-[dslowarmrellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_arm_release/
+[dslowarmdbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_arm_debug/badge/icon
+[dslowarmdbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_arm_debug/
+[dslowarmtesticon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_arm_test/badge/icon
+[dslowarmtestlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_arm_test/
+[dslowarmrelicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_arm_release/badge/icon
+[dslowarmrellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_slow_arm_release/
 
-[dslowlinuxdbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_ubuntu_linux_debug/badge/icon
-[dslowlinuxdbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_ubuntu_linux_debug/
-[dslowlinuxtesticon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_ubuntu_linux_test/badge/icon
-[dslowlinuxtestlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_ubuntu_linux_test/
-[dslowlinuxrelicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_ubuntu_linux_release/badge/icon
-[dslowlinuxrellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_ubuntu_linux_release/
+[dslowlinuxdbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_ubuntu_linux_debug/badge/icon
+[dslowlinuxdbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_ubuntu_linux_debug/
+[dslowlinuxtesticon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_ubuntu_linux_test/badge/icon
+[dslowlinuxtestlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_ubuntu_linux_test/
+[dslowlinuxrelicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_ubuntu_linux_release/badge/icon
+[dslowlinuxrellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_ubuntu_linux_release/
 
-[dslowlinuxsdbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_ubuntu_linux_debug_static/badge/icon
-[dslowlinuxsdbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_ubuntu_linux_debug_static/
-[dslowlinuxstesticon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_ubuntu_linux_test_static/badge/icon
-[dslowlinuxstestlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_ubuntu_linux_test_static/
-[dslowlinuxsrelicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_ubuntu_linux_release_static/badge/icon
-[dslowlinuxsrellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_ubuntu_linux_release_static/
+[dslowlinuxsdbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_ubuntu_linux_debug_static/badge/icon
+[dslowlinuxsdbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_ubuntu_linux_debug_static/
+[dslowlinuxstesticon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_ubuntu_linux_test_static/badge/icon
+[dslowlinuxstestlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_ubuntu_linux_test_static/
+[dslowlinuxsrelicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_ubuntu_linux_release_static/badge/icon
+[dslowlinuxsrellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_ubuntu_linux_release_static/
 
-[dslowosxsdbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_osx_osx_debug_static/badge/icon
-[dslowosxsdbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_osx_osx_debug_static/
-[dslowosxstesticon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_osx_osx_test_static/badge/icon
-[dslowosxstestlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_osx_osx_test_static/
-[dslowosxsrelicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_osx_osx_release_static/badge/icon
-[dslowosxsrellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_osx_osx_release_static/
+[dslowosxsdbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_osx_osx_debug_static/badge/icon
+[dslowosxsdbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_osx_osx_debug_static/
+[dslowosxstesticon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_osx_osx_test_static/badge/icon
+[dslowosxstestlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_osx_osx_test_static/
+[dslowosxsrelicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_osx_osx_release_static/badge/icon
+[dslowosxsrellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_osx_osx_release_static/
 
 ## DisableJIT Builds
 
@@ -124,26 +124,26 @@ Once a day, we run all of our usual build configurations with JIT excluded from 
 | __Windows (x86)__ | [![ddjx86debug][ddjx86dbgicon]][ddjx86dbglink] | [![ddjx86test][ddjx86testicon]][ddjx86testlink] | [![ddjx86release][ddjx86relicon]][ddjx86rellink] |
 | __Windows (ARM)__ | [![ddjarmdebug][ddjarmdbgicon]][ddjarmdbglink] | [![ddjarmtest][ddjarmtesticon]][ddjarmtestlink] | [![ddjarmrelease][ddjarmrelicon]][ddjarmrellink] |
 
-[ddjx64dbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_x64_debug/badge/icon
-[ddjx64dbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_x64_debug/
-[ddjx64testicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_x64_test/badge/icon
-[ddjx64testlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_x64_test/
-[ddjx64relicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_x64_release/badge/icon
-[ddjx64rellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_x64_release/
+[ddjx64dbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_x64_debug/badge/icon
+[ddjx64dbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_x64_debug/
+[ddjx64testicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_x64_test/badge/icon
+[ddjx64testlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_x64_test/
+[ddjx64relicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_x64_release/badge/icon
+[ddjx64rellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_x64_release/
 
-[ddjx86dbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_x86_debug/badge/icon
-[ddjx86dbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_x86_debug/
-[ddjx86testicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_x86_test/badge/icon
-[ddjx86testlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_x86_test/
-[ddjx86relicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_x86_release/badge/icon
-[ddjx86rellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_x86_release/
+[ddjx86dbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_x86_debug/badge/icon
+[ddjx86dbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_x86_debug/
+[ddjx86testicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_x86_test/badge/icon
+[ddjx86testlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_x86_test/
+[ddjx86relicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_x86_release/badge/icon
+[ddjx86rellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_x86_release/
 
-[ddjarmdbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_arm_debug/badge/icon
-[ddjarmdbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_arm_debug/
-[ddjarmtesticon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_arm_test/badge/icon
-[ddjarmtestlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_arm_test/
-[ddjarmrelicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_arm_release/badge/icon
-[ddjarmrellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_arm_release/
+[ddjarmdbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_arm_debug/badge/icon
+[ddjarmdbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_arm_debug/
+[ddjarmtesticon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_arm_test/badge/icon
+[ddjarmtestlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_arm_test/
+[ddjarmrelicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_arm_release/badge/icon
+[ddjarmrellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_disablejit_arm_release/
 
 ## Legacy Builds
 
@@ -154,16 +154,16 @@ Once a day, we run builds of some configurations using Windows 7 (Windows Server
 | __Windows (x64)__ | [![dd12x64dbg][dd12x64dbgicon]][dd12x64dbglink] | [![dd12x64test][dd12x64testicon]][dd12x64testlink] | [![dd12x64release][dd12x64relicon]][dd12x64rellink] |
 | __Windows (x86)__ | [![dd12x86dbg][dd12x86dbgicon]][dd12x86dbglink] | [![dd12x86test][dd12x86testicon]][dd12x86testlink] | [![dd12x86release][dd12x86relicon]][dd12x86rellink] |
 
-[dd12x64dbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_dev12_x64_debug/badge/icon
-[dd12x64dbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_dev12_x64_debug/
-[dd12x64testicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_dev12_x64_test/badge/icon
-[dd12x64testlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_dev12_x64_test/
-[dd12x64relicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_dev12_x64_release/badge/icon
-[dd12x64rellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_dev12_x64_release/
+[dd12x64dbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_dev12_x64_debug/badge/icon
+[dd12x64dbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_dev12_x64_debug/
+[dd12x64testicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_dev12_x64_test/badge/icon
+[dd12x64testlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_dev12_x64_test/
+[dd12x64relicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_dev12_x64_release/badge/icon
+[dd12x64rellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_dev12_x64_release/
 
-[dd12x86dbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_dev12_x86_debug/badge/icon
-[dd12x86dbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_dev12_x86_debug/
-[dd12x86testicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_dev12_x86_test/badge/icon
-[dd12x86testlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_dev12_x86_test/
-[dd12x86relicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_dev12_x86_release/badge/icon
-[dd12x86rellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_dev12_x86_release/
+[dd12x86dbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_dev12_x86_debug/badge/icon
+[dd12x86dbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_dev12_x86_debug/
+[dd12x86testicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_dev12_x86_test/badge/icon
+[dd12x86testlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_dev12_x86_test/
+[dd12x86relicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_dev12_x86_release/badge/icon
+[dd12x86rellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/release_1.3/job/daily_dev12_x86_release/

--- a/Build-Status.md
+++ b/Build-Status.md
@@ -15,47 +15,47 @@ For every commit we build and test of all of our build configurations on Windows
 
 *If you see badges reading "Build: Unknown" it is likely because a build was skipped due to changes being only in files known not to affect the health of the build.*
 
-[x64dbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/x64_debug/badge/icon
-[x64dbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/x64_debug/
-[x64testicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/x64_test/badge/icon
-[x64testlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/x64_test/
-[x64relicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/x64_release/badge/icon
-[x64rellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/x64_release/
+[x64dbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/x64_debug/badge/icon
+[x64dbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/x64_debug/
+[x64testicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/x64_test/badge/icon
+[x64testlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/x64_test/
+[x64relicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/x64_release/badge/icon
+[x64rellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/x64_release/
 
-[x86dbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/x86_debug/badge/icon
-[x86dbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/x86_debug/
-[x86testicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/x86_test/badge/icon
-[x86testlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/x86_test/
-[x86relicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/x86_release/badge/icon
-[x86rellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/x86_release/
+[x86dbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/x86_debug/badge/icon
+[x86dbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/x86_debug/
+[x86testicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/x86_test/badge/icon
+[x86testlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/x86_test/
+[x86relicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/x86_release/badge/icon
+[x86rellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/x86_release/
 
-[armdbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/arm_debug/badge/icon
-[armdbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/arm_debug/
-[armtesticon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/arm_test/badge/icon
-[armtestlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/arm_test/
-[armrelicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/arm_release/badge/icon
-[armrellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/arm_release/
+[armdbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/arm_debug/badge/icon
+[armdbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/arm_debug/
+[armtesticon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/arm_test/badge/icon
+[armtestlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/arm_test/
+[armrelicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/arm_release/badge/icon
+[armrellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/arm_release/
 
-[linuxdbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/ubuntu_linux_debug/badge/icon
-[linuxdbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/ubuntu_linux_debug/
-[linuxtesticon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/ubuntu_linux_test/badge/icon
-[linuxtestlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/ubuntu_linux_test/
-[linuxrelicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/ubuntu_linux_release/badge/icon
-[linuxrellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/ubuntu_linux_release/
+[linuxdbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/ubuntu_linux_debug/badge/icon
+[linuxdbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/ubuntu_linux_debug/
+[linuxtesticon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/ubuntu_linux_test/badge/icon
+[linuxtestlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/ubuntu_linux_test/
+[linuxrelicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/ubuntu_linux_release/badge/icon
+[linuxrellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/ubuntu_linux_release/
 
-[linuxsdbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/ubuntu_linux_debug_static/badge/icon
-[linuxsdbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/ubuntu_linux_debug_static/
-[linuxstesticon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/ubuntu_linux_test_static/badge/icon
-[linuxstestlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/ubuntu_linux_test_static/
-[linuxsrelicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/ubuntu_linux_release_static/badge/icon
-[linuxsrellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/ubuntu_linux_release_static/
+[linuxsdbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/ubuntu_linux_debug_static/badge/icon
+[linuxsdbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/ubuntu_linux_debug_static/
+[linuxstesticon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/ubuntu_linux_test_static/badge/icon
+[linuxstestlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/ubuntu_linux_test_static/
+[linuxsrelicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/ubuntu_linux_release_static/badge/icon
+[linuxsrellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/ubuntu_linux_release_static/
 
-[osxsdbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/osx_osx_debug_static/badge/icon
-[osxsdbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/osx_osx_debug_static/
-[osxstesticon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/osx_osx_test_static/badge/icon
-[osxstestlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/osx_osx_test_static/
-[osxsrelicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/osx_osx_release_static/badge/icon
-[osxsrellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/osx_osx_release_static/
+[osxsdbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/osx_osx_debug_static/badge/icon
+[osxsdbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/osx_osx_debug_static/
+[osxstesticon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/osx_osx_test_static/badge/icon
+[osxstestlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/osx_osx_test_static/
+[osxsrelicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/osx_osx_release_static/badge/icon
+[osxsrellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/osx_osx_release_static/
 
 # Daily Builds
 
@@ -72,47 +72,47 @@ Once a day, we run all the same builds as the Rolling Builds above, but we run a
 | __Ubuntu 16.04 (x64 static)__ | [![dslowlinuxsdebug][dslowlinuxsdbgicon]][dslowlinuxsdbglink] | [![dslowlinuxstest][dslowlinuxstesticon]][dslowlinuxstestlink] | [![dslowlinuxsrelease][dslowlinuxsrelicon]][dslowlinuxsrellink] |
 | __OS X 10.9 (x64 static)__    | [![dslowosxsdebug][dslowosxsdbgicon]][dslowosxsdbglink] | [![dslowosxstest][dslowosxstesticon]][dslowosxstestlink] | [![dslowosxsrelease][dslowosxsrelicon]][dslowosxsrellink] |
 
-[dslowx64dbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_x64_debug/badge/icon
-[dslowx64dbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_x64_debug/
-[dslowx64testicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_x64_test/badge/icon
-[dslowx64testlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_x64_test/
-[dslowx64relicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_x64_release/badge/icon
-[dslowx64rellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_x64_release/
+[dslowx64dbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_x64_debug/badge/icon
+[dslowx64dbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_x64_debug/
+[dslowx64testicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_x64_test/badge/icon
+[dslowx64testlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_x64_test/
+[dslowx64relicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_x64_release/badge/icon
+[dslowx64rellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_x64_release/
 
-[dslowx86dbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_x86_debug/badge/icon
-[dslowx86dbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_x86_debug/
-[dslowx86testicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_x86_test/badge/icon
-[dslowx86testlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_x86_test/
-[dslowx86relicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_x86_release/badge/icon
-[dslowx86rellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_x86_release/
+[dslowx86dbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_x86_debug/badge/icon
+[dslowx86dbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_x86_debug/
+[dslowx86testicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_x86_test/badge/icon
+[dslowx86testlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_x86_test/
+[dslowx86relicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_x86_release/badge/icon
+[dslowx86rellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_x86_release/
 
-[dslowarmdbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_arm_debug/badge/icon
-[dslowarmdbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_arm_debug/
-[dslowarmtesticon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_arm_test/badge/icon
-[dslowarmtestlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_arm_test/
-[dslowarmrelicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_arm_release/badge/icon
-[dslowarmrellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_arm_release/
+[dslowarmdbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_arm_debug/badge/icon
+[dslowarmdbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_arm_debug/
+[dslowarmtesticon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_arm_test/badge/icon
+[dslowarmtestlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_arm_test/
+[dslowarmrelicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_arm_release/badge/icon
+[dslowarmrellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_slow_arm_release/
 
-[dslowlinuxdbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_ubuntu_linux_debug/badge/icon
-[dslowlinuxdbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_ubuntu_linux_debug/
-[dslowlinuxtesticon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_ubuntu_linux_test/badge/icon
-[dslowlinuxtestlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_ubuntu_linux_test/
-[dslowlinuxrelicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_ubuntu_linux_release/badge/icon
-[dslowlinuxrellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_ubuntu_linux_release/
+[dslowlinuxdbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_ubuntu_linux_debug/badge/icon
+[dslowlinuxdbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_ubuntu_linux_debug/
+[dslowlinuxtesticon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_ubuntu_linux_test/badge/icon
+[dslowlinuxtestlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_ubuntu_linux_test/
+[dslowlinuxrelicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_ubuntu_linux_release/badge/icon
+[dslowlinuxrellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_ubuntu_linux_release/
 
-[dslowlinuxsdbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_ubuntu_linux_debug_static/badge/icon
-[dslowlinuxsdbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_ubuntu_linux_debug_static/
-[dslowlinuxstesticon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_ubuntu_linux_test_static/badge/icon
-[dslowlinuxstestlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_ubuntu_linux_test_static/
-[dslowlinuxsrelicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_ubuntu_linux_release_static/badge/icon
-[dslowlinuxsrellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_ubuntu_linux_release_static/
+[dslowlinuxsdbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_ubuntu_linux_debug_static/badge/icon
+[dslowlinuxsdbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_ubuntu_linux_debug_static/
+[dslowlinuxstesticon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_ubuntu_linux_test_static/badge/icon
+[dslowlinuxstestlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_ubuntu_linux_test_static/
+[dslowlinuxsrelicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_ubuntu_linux_release_static/badge/icon
+[dslowlinuxsrellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_ubuntu_linux_release_static/
 
-[dslowosxsdbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_osx_osx_debug_static/badge/icon
-[dslowosxsdbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_osx_osx_debug_static/
-[dslowosxstesticon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_osx_osx_test_static/badge/icon
-[dslowosxstestlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_osx_osx_test_static/
-[dslowosxsrelicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_osx_osx_release_static/badge/icon
-[dslowosxsrellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_osx_osx_release_static/
+[dslowosxsdbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_osx_osx_debug_static/badge/icon
+[dslowosxsdbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_osx_osx_debug_static/
+[dslowosxstesticon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_osx_osx_test_static/badge/icon
+[dslowosxstestlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_osx_osx_test_static/
+[dslowosxsrelicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_osx_osx_release_static/badge/icon
+[dslowosxsrellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_osx_osx_release_static/
 
 ## DisableJIT Builds
 
@@ -124,26 +124,26 @@ Once a day, we run all of our usual build configurations with JIT excluded from 
 | __Windows (x86)__ | [![ddjx86debug][ddjx86dbgicon]][ddjx86dbglink] | [![ddjx86test][ddjx86testicon]][ddjx86testlink] | [![ddjx86release][ddjx86relicon]][ddjx86rellink] |
 | __Windows (ARM)__ | [![ddjarmdebug][ddjarmdbgicon]][ddjarmdbglink] | [![ddjarmtest][ddjarmtesticon]][ddjarmtestlink] | [![ddjarmrelease][ddjarmrelicon]][ddjarmrellink] |
 
-[ddjx64dbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_x64_debug/badge/icon
-[ddjx64dbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_x64_debug/
-[ddjx64testicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_x64_test/badge/icon
-[ddjx64testlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_x64_test/
-[ddjx64relicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_x64_release/badge/icon
-[ddjx64rellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_x64_release/
+[ddjx64dbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_x64_debug/badge/icon
+[ddjx64dbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_x64_debug/
+[ddjx64testicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_x64_test/badge/icon
+[ddjx64testlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_x64_test/
+[ddjx64relicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_x64_release/badge/icon
+[ddjx64rellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_x64_release/
 
-[ddjx86dbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_x86_debug/badge/icon
-[ddjx86dbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_x86_debug/
-[ddjx86testicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_x86_test/badge/icon
-[ddjx86testlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_x86_test/
-[ddjx86relicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_x86_release/badge/icon
-[ddjx86rellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_x86_release/
+[ddjx86dbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_x86_debug/badge/icon
+[ddjx86dbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_x86_debug/
+[ddjx86testicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_x86_test/badge/icon
+[ddjx86testlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_x86_test/
+[ddjx86relicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_x86_release/badge/icon
+[ddjx86rellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_x86_release/
 
-[ddjarmdbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_arm_debug/badge/icon
-[ddjarmdbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_arm_debug/
-[ddjarmtesticon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_arm_test/badge/icon
-[ddjarmtestlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_arm_test/
-[ddjarmrelicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_arm_release/badge/icon
-[ddjarmrellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_arm_release/
+[ddjarmdbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_arm_debug/badge/icon
+[ddjarmdbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_arm_debug/
+[ddjarmtesticon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_arm_test/badge/icon
+[ddjarmtestlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_arm_test/
+[ddjarmrelicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_arm_release/badge/icon
+[ddjarmrellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_disablejit_arm_release/
 
 ## Legacy Builds
 
@@ -154,16 +154,16 @@ Once a day, we run builds of some configurations using Windows 7 (Windows Server
 | __Windows (x64)__ | [![dd12x64dbg][dd12x64dbgicon]][dd12x64dbglink] | [![dd12x64test][dd12x64testicon]][dd12x64testlink] | [![dd12x64release][dd12x64relicon]][dd12x64rellink] |
 | __Windows (x86)__ | [![dd12x86dbg][dd12x86dbgicon]][dd12x86dbglink] | [![dd12x86test][dd12x86testicon]][dd12x86testlink] | [![dd12x86release][dd12x86relicon]][dd12x86rellink] |
 
-[dd12x64dbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_dev12_x64_debug/badge/icon
-[dd12x64dbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_dev12_x64_debug/
-[dd12x64testicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_dev12_x64_test/badge/icon
-[dd12x64testlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_dev12_x64_test/
-[dd12x64relicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_dev12_x64_release/badge/icon
-[dd12x64rellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_dev12_x64_release/
+[dd12x64dbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_dev12_x64_debug/badge/icon
+[dd12x64dbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_dev12_x64_debug/
+[dd12x64testicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_dev12_x64_test/badge/icon
+[dd12x64testlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_dev12_x64_test/
+[dd12x64relicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_dev12_x64_release/badge/icon
+[dd12x64rellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_dev12_x64_release/
 
-[dd12x86dbgicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_dev12_x86_debug/badge/icon
-[dd12x86dbglink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_dev12_x86_debug/
-[dd12x86testicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_dev12_x86_test/badge/icon
-[dd12x86testlink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_dev12_x86_test/
-[dd12x86relicon]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_dev12_x86_release/badge/icon
-[dd12x86rellink]: http://dotnet-ci.cloudapp.net/job/Microsoft_ChakraCore/job/master/job/daily_dev12_x86_release/
+[dd12x86dbgicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_dev12_x86_debug/badge/icon
+[dd12x86dbglink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_dev12_x86_debug/
+[dd12x86testicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_dev12_x86_test/badge/icon
+[dd12x86testlink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_dev12_x86_test/
+[dd12x86relicon]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_dev12_x86_release/badge/icon
+[dd12x86rellink]: https://ci.dot.net/job/Microsoft_ChakraCore/job/master/job/daily_dev12_x86_release/


### PR DESCRIPTION
Update Jenkins links to https://ci.dot.net because http://dotnet-ci.cloudapp.net is deprecated.

Also use HTTPS instead of HTTP.
