### PR TITLE
JsCreateString(Utf16) requires active script context?

### DIFF
--- a/reference/JsCreateString.md
+++ b/reference/JsCreateString.md
@@ -19,4 +19,6 @@ The code **JsNoError** if the operation succeeded, a failure code otherwise.
 ### Remarks 
 **This API is experimental and may have breaking change later.** 
 
+Requires an active script context.
+
 Input string can be either ASCII or Utf8.

--- a/reference/JsCreateStringUtf16.md
+++ b/reference/JsCreateStringUtf16.md
@@ -18,4 +18,6 @@ The code **JsNoError** if the operation succeeded, a failure code otherwise.
 ### Remarks 
 **This API is experimental and may have breaking change later.** 
 
+Requires an active script context.
+
 Expects Utf16 string.


### PR DESCRIPTION
It seems to me that `JsCreateString` and `JsCreateStringUtf16` require an active script context. They both return `JsErrorNoCurrentContext` if `JsSetCurrentContext` is not called earlier. But the doc doesn't mention they "require an active script context" in the "Remarks" section. I wonder if this note should be added.

The following is the test code:

```
#include <iostream>
#include <ChakraCore.h>
#pragma comment(lib, "ChakraCore.lib")

int main(void)
{
    char s[] = "hello";
    wchar_t str[] = L"hello";
    JsValueRef val;
    JsErrorCode err;
    if ((err = JsCreateStringUtf16((const uint16_t*)str, sizeof(str), &val)) != JsNoError)
    {
        std::wcout << L"JsCreateStringUtf16 fails with error " << err << L"\n";
    }
    if ((err = JsCreateString(s, sizeof(s), &val)) != JsNoError)
    {
        std::wcout << L"JsCreateString fails with error " << err << L"\n";
    }
    getchar();
    return 0;
}
```

