### PR TITLE
Rename Js(Copy|Create)PropertyIdUtf8 to Js(Copy|Create)PropertyId

### DIFF
--- a/JavaScript-Runtime-(JSRT)-Reference.md
+++ b/JavaScript-Runtime-(JSRT)-Reference.md
@@ -60,7 +60,7 @@ References of JSRT typedefs, constants, enumerations and APIs.
 * [[JsCreateNamedFunction]]
 * [[JsCreateObject]]
 * [[JsCreatePromise]]
-* [[JsCreatePropertyIdUtf8]]
+* [[JsCreatePropertyId]]
 * [[JsCreateRangeError]]
 * [[JsCreateReferenceError]]
 * [[JsCreateRuntime]]

--- a/JavaScript-Runtime-(JSRT)-Reference.md
+++ b/JavaScript-Runtime-(JSRT)-Reference.md
@@ -48,7 +48,7 @@ References of JSRT typedefs, constants, enumerations and APIs.
 * [[JsCopyString]]
 * [[JsCopyStringOneByte]]
 * [[JsCopyStringUtf16]]
-* [[JsCopyPropertyIdUtf8]]
+* [[JsCopyPropertyId]]
 * [[JsCreateArray]]
 * [[JsCreateArrayBuffer]]
 * [[JsCreateContext]]

--- a/reference/JsCopyPropertyId.md
+++ b/reference/JsCopyPropertyId.md
@@ -2,9 +2,9 @@ Copies the name associated with the property ID into a buffer.
 ### Syntax 
 ```
 CHAKRA_API
-       JsCopyPropertyIdUtf8(
+       JsCopyPropertyId(
         _In_ JsPropertyIdRef propertyId,
-        _Out_ uint8_t* buffer,
+        _Out_ char* buffer,
         _In_ size_t bufferSize,
         _Out_ size_t* length);
 ```

--- a/reference/JsCreatePropertyId.md
+++ b/reference/JsCreatePropertyId.md
@@ -2,7 +2,7 @@ Creates the property ID associated with the name.
 ### Syntax 
 ```
 CHAKRA_API
-       JsCreatePropertyIdUtf8(
+       JsCreatePropertyId(
         _In_z_ const char *name,
         _In_ size_t length,
         _Out_ JsPropertyIdRef *propertyId);

--- a/reference/JsGetPropertyIdFromName.md
+++ b/reference/JsGetPropertyIdFromName.md
@@ -14,6 +14,6 @@ STDAPI_(JsErrorCode)
 The code **JsNoError** if the operation succeeded, a failure code otherwise.
 
 ### Remarks
-This API is Windows-only (see [[JsCreatePropertyIdUtf8]] for cross-platform equivalent).
+This API is Windows-only (see [[JsCreatePropertyId]] for cross-platform equivalent).
 Property IDs are specific to a context and cannot be used across contexts.
 Requires an active script context.

--- a/reference/JsGetPropertyNameFromId.md
+++ b/reference/JsGetPropertyNameFromId.md
@@ -14,7 +14,7 @@ STDAPI_(JsErrorCode)
 The code **JsNoError** if the operation succeeded, a failure code otherwise.
 
 ### Remarks
-This API is Windows-only (see [[JsCopyPropertyIdUtf8]] for cross-platform equivalent).
+This API is Windows-only (see [[JsCopyPropertyId]] for cross-platform equivalent).
 Requires an active script context.
 The returned buffer is valid as long as the runtime is alive and cannot be used
 once the runtime has been disposed.


### PR DESCRIPTION
There is no exported function called JsCopyPropertyIdUtf8, but there is JsCopyPropertyId,
[declared](https://github.com/Microsoft/ChakraCore/blob/6ec963b359d7c515a1bb05b5ffc169fd321e28a7/lib/Jsrt/ChakraCore.h#L446) in ChakraCore.h. So update the doc to match the source code.