### PR TITLE
Correct JsSetRuntimeBeforeCollectCallback name

### DIFF
--- a/reference/JsBeforeCollectCallback.md
+++ b/reference/JsBeforeCollectCallback.md
@@ -4,4 +4,4 @@ A callback called before collection.
 typedef void (CALLBACK *JsBeforeCollectCallback)(_In_opt_ void *callbackState);
 ```
 ### Remarks 
-Use **JsSetBeforeCollectCallback<** to register this callback.
+Use **JsSetRuntimeBeforeCollectCallback<** to register this callback.


### PR DESCRIPTION
Was reading the wiki and noticed this mistake - JsSetRuntimeBeforeCollectCallback was referred to as JsSetBeforeCollectCallback on this page - there is no function called JsSetBeforeCollectCallback.