### PR TITLE
typo fixes

### DIFF
--- a/reference/JsErrorCode.md
+++ b/reference/JsErrorCode.md
@@ -31,7 +31,7 @@ enum JsErrorCode : unsigned int
 * __JsErrorPropertyNotSymbol__: A hosting API that operates on symbol property ids but was called with a non-symbol property id. The error code is returned by JsGetSymbolFromPropertyId if the function is called with non-symbol property id.
 * __JsErrorPropertyNotString__: A hosting API that operates on string property ids but was called with a non-string property id. The error code is returned by existing JsGetPropertyNamefromId if the function is called with non-string property id.
 * __JsErrorInvalidContext__: Module evaluation is called in wrong context.
-* __JsInvalidModuleHostInfoKind__: Module evaluation is called in wrong context.
+* __JsInvalidModuleHostInfoKind__: The Module HostInfoKind provided was invalid.
 * __JsErrorModuleParsed__: Module was parsed already when JsParseModuleSource is called.
 * __JsNoWeakRefRequired__: Argument passed to JsCreateWeakReference is a primitive that is not managed by the GC. No weak reference is required, the value will never be collected.
 * __JsErrorPromisePending__: The `Promise` object is still in the pending state.

--- a/reference/JsIdle.md
+++ b/reference/JsIdle.md
@@ -1,4 +1,4 @@
-Tells the runtime to do any idle processing it need to do. 
+Tells the runtime to do any idle processing it needs to do.
 ### Syntax 
 ```
 STDAPI_(JsErrorCode)

--- a/reference/JsRelease.md
+++ b/reference/JsRelease.md
@@ -7,7 +7,7 @@ STDAPI_(JsErrorCode)
     _Out_opt_ unsigned int *count);
 ```
 ### Parameters 
-* __ref__: The object to add a reference to.
+* __ref__: The object to remove the reference from.
 * __count__: The object's new reference count (can pass in null).
 
 ### Return Value 


### PR DESCRIPTION
Sync the typo fixes from https://github.com/Microsoft/ChakraCore/pull/5659

Note this is 3 of the 4 corrections that PR made to the headers as the 4th is/was already correct in the wiki.